### PR TITLE
Support MMLU‑Pro evaluation

### DIFF
--- a/run/evaluation_LM.sh
+++ b/run/evaluation_LM.sh
@@ -10,4 +10,7 @@ export HF_HOME="/mnt/parscratch/users/ac1xwa/huggingface"
 module load Anaconda3/2022.05
 source activate cogbias
 huggingface-cli login --token <token>
-python src/eval_language_modelling.py --model_name "XiWangEric/literary-classicist-llama3" --dataset_name "mmlu" --task "multi_subject_mc"
+python src/eval_language_modelling.py \
+  --model_name "XiWangEric/literary-classicist-llama3" \
+  --dataset_name "mmlu_pro" \
+  --task "multi_subject_mc"

--- a/src/eval_language_modelling.py
+++ b/src/eval_language_modelling.py
@@ -92,8 +92,14 @@ def main(args):
     else:
         raise ValueError("Unsupported task")
 
-    if args.dataset_name == "mmlu":
-        dataset = load_dataset("cais/mmlu", "abstract_algebra")
+    dataset_map = {
+        "mmlu": "cais/mmlu",
+        "mmlu_redux": "cais/mmlu_redux",
+        "mmlu_pro": "cais/mmlu_pro",
+    }
+
+    if args.dataset_name in dataset_map:
+        dataset = load_dataset(dataset_map[args.dataset_name], "abstract_algebra")
     else:
         dataset = load_dataset(args.dataset_name)
     accuracy = evaluate_fn(model, tokenizer, dataset["test"])


### PR DESCRIPTION
## Summary
- support loading `mmlu_pro` in the language modelling evaluation script
- run evaluation on `mmlu_pro` in the evaluation job script

## Testing
- `python -m py_compile src/eval_language_modelling.py`
- `python -m py_compile src/evaluation/mmlu_eval.py`


------
https://chatgpt.com/codex/tasks/task_e_686cfa7fce948330ba1d9bbec596c4e4